### PR TITLE
Enable workflow schedule and add Keepalive job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,8 +11,8 @@ on:
       - loading-screen-rework
 
   # Regularly run this workflow (on the default branch) to update the available versions
-  # schedule:
-  #   - cron: '0 * * * *'
+  schedule:
+    - cron: '0 * * * *'
 
   # Allow manual dispatch of this workflow
   workflow_dispatch:
@@ -70,3 +70,22 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # Keep this workflow alive even if there were no commits in the last 60 days
+  # (see https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow)
+  keepalive:
+    name: Keepalive
+    runs-on: ubuntu-latest
+
+    if: github.event_name == 'schedule'
+
+    steps:
+      - name: Keep workflow alive
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.actions.enableWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'main.yaml'
+            })


### PR DESCRIPTION
Github workflows get disabled if there were no commits in the last 60 days (see https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow).

This can be avoided by enabling the workflow via the API (this resets the timer for the workflow). See https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#enable-a-workflow for the API endpoint documentation.

This adds a new job to the workflow that just calls this endpoint to make sure the workflow never gets disabled.