### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[{*.yaml,*.yml,*.toml}]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true


### PR DESCRIPTION
This adds an [`.editorconfig`](https://editorconfig.org/) file to make sure all files follow a consistent style.

Motivated by https://github.com/knoxfighter/addon-repo/pull/4#discussion_r1797629712