### PR TITLE
Fix missing token in CI to download previous manifest

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Download existing manifest
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: wget -O out/manifest.json "$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')manifest.json"
 
       - name: Create manifest


### PR DESCRIPTION
This fixes the error introduced in #7
> gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
> ```
> env:
>   GH_TOKEN: ${{ github.token }}
> ```
source: https://github.com/knoxfighter/addon-repo/actions/runs/11429749104
