### PR TITLE
Fix error handling when download of previous manifest fails

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: wget -O out/manifest.json "$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')manifest.json"
+        run: wget -O /tmp/manifest.json "$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')manifest.json" && mv /tmp/manifest.json out/manifest.json
 
       - name: Create manifest
         uses: knoxfighter/generate-loading-screen@main


### PR DESCRIPTION
If the download failed, the next step would fail with "Unexpected end of JSON input.".

Now the manifest is first downloaded into `/tmp/`, and only moved to the correct path if the download succeeds.

I've actually verified that this works this time 😅